### PR TITLE
FIX: imports issues

### DIFF
--- a/rtsp.py
+++ b/rtsp.py
@@ -4,7 +4,7 @@ import socket
 import os
 import re
 import threading
-from sys import stdout
+from sys import stdout,exit
 from colorama import Fore, init
 init(autoreset=True)
 
@@ -94,7 +94,7 @@ def main():
             ip_list = f.readlines()
     except FileNotFoundError:
         print(f"{FY}[ERROR!] - {FR}Bro? Whutt are you doin?{target_file}")
-        sys.exit(1)
+        exit(1)
 
     num_threads = int(input(f"{FY}[Threads]: {FW}") or "10")
 


### PR DESCRIPTION
fixed python the following python error: "NameError: name 'sys' is not defined. Did you forget to import 'sys'?"

## Summary by Sourcery

Fix missing import errors and streamline script execution in rtsp.py

Bug Fixes:
- Replace sys.exit(1) with built-in exit(1) to avoid NameError when sys is not imported

Enhancements:
- Remove direct main() call under the __main__ guard to adjust script invocation